### PR TITLE
3.6.4 - Основы Flutter

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const App());
 }
 
 class MyApp extends StatelessWidget {
@@ -29,6 +29,18 @@ class MyApp extends StatelessWidget {
   }
 }
 
+class App extends StatelessWidget {
+  const App({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'My first app',
+      home: MyFirstWidget(),
+    );
+  }
+}
+
 class MyFirstWidget extends StatelessWidget {
   var _counter = 0;
   MyFirstWidget({Key? key}) : super(key: key);
@@ -42,6 +54,8 @@ class MyFirstWidget extends StatelessWidget {
       ),
     );
   }
+
+  //Type contextRunType() => context.runtimeType;
 }
 
 class MyFirstStatefulWidget extends StatefulWidget {
@@ -49,6 +63,8 @@ class MyFirstStatefulWidget extends StatefulWidget {
 
   @override
   State<MyFirstStatefulWidget> createState() => _MyFirstStatefulWidgetState();
+
+  //Type contextRunType() => context.runtimeType;
 }
 
 class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
@@ -63,6 +79,8 @@ class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
       ),
     );
   }
+
+  Type contextRunType() => context.runtimeType;
 }
 
 class MyHomePage extends StatefulWidget {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:places/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -14,17 +14,5 @@ void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const App());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
   });
 }


### PR DESCRIPTION
1. Переименуйте файл main.dart в start.dart. Запустите проект. Почему результат именно таков?
	- **_При запуске проекта, без указания файла (flutter run -d emulator-xxxx), точка входа является файл main.dart (Target file "lib\main.dart" not found)_**
2. Верните именование.
3. В файле main.dart создайте виджет приложения. Назовите его App.
4. В методе build() верните MaterialApp в поле home поставьте Stateless виджет из предыдущего домашнего задания(см. урок про виджеты). Рассмотрите его параметры. Задайте поле title. Запустите на Android. Где отобразится значение этого поля?
	- **_На Android обычно видно, когда мы сворачиваем приложение (Recent apps). В эмуляторе с Android 7.0 смог увидеть._** 
5. Перейдем к рассмотрению контекста. В вашем Stateless виджет создайте метод без аргументов, который будет возвращать context.runtimeType. Получится ли реализовать подобное в данном виджете?
	- **_Нет. Не находит "переменную" context (Undefined name 'context')._**
6. Проделайте предыдущий пункт в рамках Stateful. В чем разница?
	- **_context будет доступен в классе состояния Stateful widget-а._**