### PR TITLE
4.8 - Работа с размерами во Flutter

### DIFF
--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -18,7 +18,7 @@ class SightCard extends StatelessWidget {
     return Container(
       margin: margin,
       decoration: const BoxDecoration(
-        color: AppColors.whiteGreen,
+        color: AppColors.background,
         borderRadius: BorderRadius.all(
           AppSizes.radiusNormal,
         ),
@@ -26,8 +26,12 @@ class SightCard extends StatelessWidget {
       child: Column(
         children: [
           Container(
-            constraints: const BoxConstraints(
-              maxHeight: AppSizes.heightImageCard,
+            height: AppSizes.heightImageCard,
+            decoration: const BoxDecoration(
+              color: AppColors.whiteGreen,
+              borderRadius: BorderRadius.vertical(
+                top: AppSizes.radiusNormal,
+              ),
             ),
             child: Stack(
               children: [
@@ -53,41 +57,48 @@ class SightCard extends StatelessWidget {
               ],
             ),
           ),
-          Container(
-            width: double.infinity,
-            decoration: const BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.vertical(
-                bottom: AppSizes.radiusNormal,
-              ),
+          _CardContent(sight: sight),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardContent extends StatelessWidget {
+  final Sight sight;
+
+  const _CardContent({
+    Key? key,
+    required this.sight,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(
+        AppSizes.paddingCommon,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            sight.name,
+            style: AppTextStyles.text.copyWith(
+              color: AppColors.secondary,
             ),
-            padding: const EdgeInsets.all(
-              AppSizes.paddingCommon,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(
+            height: AppSizes.paddingSubtitleDivider,
+          ),
+          Text(
+            sight.details,
+            style: AppTextStyles.small.copyWith(
+              color: AppColors.secondary2,
             ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  sight.name,
-                  style: AppTextStyles.text.copyWith(
-                    color: AppColors.secondary,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(
-                  height: AppSizes.paddingSubtitleDivider,
-                ),
-                Text(
-                  sight.details,
-                  style: AppTextStyles.small.copyWith(
-                    color: AppColors.secondary2,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -18,76 +18,90 @@ class SightCard extends StatelessWidget {
     return Container(
       margin: margin,
       decoration: const BoxDecoration(
-        color: AppColors.whiteGreen,
+        color: AppColors.background,
         borderRadius: BorderRadius.all(
           AppSizes.radiusNormal,
         ),
       ),
       child: Column(
         children: [
-          Container(
-            constraints: const BoxConstraints(
-              maxHeight: AppSizes.heightImageCard,
-            ),
-            child: Stack(
-              children: [
-                Align(
-                  alignment: Alignment.topLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.all(AppSizes.paddingCommon),
-                    child: Text(
-                      sight.type.name.toLowerCase(),
-                      style: AppTextStyles.smallBold.copyWith(
-                        color: AppColors.white,
-                      ),
+          Stack(
+            children: [
+              Container(
+                decoration: const BoxDecoration(
+                  color: AppColors.whiteGreen,
+                  borderRadius: BorderRadius.vertical(
+                    top: AppSizes.radiusNormal,
+                  ),
+                ),
+                height: AppSizes.heightImageCard,
+              ),
+              Align(
+                alignment: Alignment.topLeft,
+                child: Padding(
+                  padding: const EdgeInsets.all(AppSizes.paddingCommon),
+                  child: Text(
+                    sight.type.name.toLowerCase(),
+                    style: AppTextStyles.smallBold.copyWith(
+                      color: AppColors.white,
                     ),
                   ),
                 ),
-                const Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
-                    child: ButtonFavorite(),
-                  ),
+              ),
+              const Align(
+                alignment: Alignment.topRight,
+                child: Padding(
+                  padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
+                  child: ButtonFavorite(),
                 ),
-              ],
+              ),
+            ],
+          ),
+          _CardContent(sight: sight),
+        ],
+      ),
+    );
+  }
+}
+
+class _CardContent extends StatelessWidget {
+  final Sight sight;
+
+  const _CardContent({
+    Key? key,
+    required this.sight,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSizes.paddingCommon),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width / 2,
+            ),
+            child: Text(
+              sight.name,
+              style: AppTextStyles.text.copyWith(
+                color: AppColors.secondary,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
             ),
           ),
-          Container(
-            width: double.infinity,
-            decoration: const BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.vertical(
-                bottom: AppSizes.radiusNormal,
-              ),
+          const SizedBox(
+            height: AppSizes.paddingSubtitleDivider,
+          ),
+          Text(
+            sight.details,
+            style: AppTextStyles.small.copyWith(
+              color: AppColors.secondary2,
             ),
-            padding: const EdgeInsets.all(
-              AppSizes.paddingCommon,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  sight.name,
-                  style: AppTextStyles.text.copyWith(
-                    color: AppColors.secondary,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(
-                  height: AppSizes.paddingSubtitleDivider,
-                ),
-                Text(
-                  sight.details,
-                  style: AppTextStyles.small.copyWith(
-                    color: AppColors.secondary2,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ],
-            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -18,90 +18,76 @@ class SightCard extends StatelessWidget {
     return Container(
       margin: margin,
       decoration: const BoxDecoration(
-        color: AppColors.background,
+        color: AppColors.whiteGreen,
         borderRadius: BorderRadius.all(
           AppSizes.radiusNormal,
         ),
       ),
       child: Column(
         children: [
-          Stack(
-            children: [
-              Container(
-                decoration: const BoxDecoration(
-                  color: AppColors.whiteGreen,
-                  borderRadius: BorderRadius.vertical(
-                    top: AppSizes.radiusNormal,
-                  ),
-                ),
-                height: AppSizes.heightImageCard,
-              ),
-              Align(
-                alignment: Alignment.topLeft,
-                child: Padding(
-                  padding: const EdgeInsets.all(AppSizes.paddingCommon),
-                  child: Text(
-                    sight.type.name.toLowerCase(),
-                    style: AppTextStyles.smallBold.copyWith(
-                      color: AppColors.white,
+          Container(
+            constraints: const BoxConstraints(
+              maxHeight: AppSizes.heightImageCard,
+            ),
+            child: Stack(
+              children: [
+                Align(
+                  alignment: Alignment.topLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.all(AppSizes.paddingCommon),
+                    child: Text(
+                      sight.type.name.toLowerCase(),
+                      style: AppTextStyles.smallBold.copyWith(
+                        color: AppColors.white,
+                      ),
                     ),
                   ),
                 ),
-              ),
-              const Align(
-                alignment: Alignment.topRight,
-                child: Padding(
-                  padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
-                  child: ButtonFavorite(),
+                const Align(
+                  alignment: Alignment.topRight,
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
+                    child: ButtonFavorite(),
+                  ),
                 ),
+              ],
+            ),
+          ),
+          Container(
+            width: double.infinity,
+            decoration: const BoxDecoration(
+              color: AppColors.background,
+              borderRadius: BorderRadius.vertical(
+                bottom: AppSizes.radiusNormal,
               ),
-            ],
-          ),
-          _CardContent(sight: sight),
-        ],
-      ),
-    );
-  }
-}
-
-class _CardContent extends StatelessWidget {
-  final Sight sight;
-
-  const _CardContent({
-    Key? key,
-    required this.sight,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(AppSizes.paddingCommon),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          ConstrainedBox(
-            constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width / 2,
             ),
-            child: Text(
-              sight.name,
-              style: AppTextStyles.text.copyWith(
-                color: AppColors.secondary,
-              ),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
+            padding: const EdgeInsets.all(
+              AppSizes.paddingCommon,
             ),
-          ),
-          const SizedBox(
-            height: AppSizes.paddingSubtitleDivider,
-          ),
-          Text(
-            sight.details,
-            style: AppTextStyles.small.copyWith(
-              color: AppColors.secondary2,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  sight.name,
+                  style: AppTextStyles.text.copyWith(
+                    color: AppColors.secondary,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(
+                  height: AppSizes.paddingSubtitleDivider,
+                ),
+                Text(
+                  sight.details,
+                  style: AppTextStyles.small.copyWith(
+                    color: AppColors.secondary2,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
             ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
           ),
         ],
       ),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -15,50 +15,53 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: margin,
-      decoration: const BoxDecoration(
-        color: AppColors.background,
-        borderRadius: BorderRadius.all(
-          AppSizes.radiusNormal,
+    return AspectRatio(
+      aspectRatio: 3 / 2,
+      child: Container(
+        margin: margin,
+        decoration: const BoxDecoration(
+          color: AppColors.background,
+          borderRadius: BorderRadius.all(
+            AppSizes.radiusNormal,
+          ),
         ),
-      ),
-      child: Column(
-        children: [
-          Container(
-            height: AppSizes.heightImageCard,
-            decoration: const BoxDecoration(
-              color: AppColors.whiteGreen,
-              borderRadius: BorderRadius.vertical(
-                top: AppSizes.radiusNormal,
+        child: Column(
+          children: [
+            Container(
+              height: AppSizes.heightImageCard,
+              decoration: const BoxDecoration(
+                color: AppColors.whiteGreen,
+                borderRadius: BorderRadius.vertical(
+                  top: AppSizes.radiusNormal,
+                ),
               ),
-            ),
-            child: Stack(
-              children: [
-                Align(
-                  alignment: Alignment.topLeft,
-                  child: Padding(
-                    padding: const EdgeInsets.all(AppSizes.paddingCommon),
-                    child: Text(
-                      sight.type.name.toLowerCase(),
-                      style: AppTextStyles.smallBold.copyWith(
-                        color: AppColors.white,
+              child: Stack(
+                children: [
+                  Align(
+                    alignment: Alignment.topLeft,
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSizes.paddingCommon),
+                      child: Text(
+                        sight.type.name.toLowerCase(),
+                        style: AppTextStyles.smallBold.copyWith(
+                          color: AppColors.white,
+                        ),
                       ),
                     ),
                   ),
-                ),
-                const Align(
-                  alignment: Alignment.topRight,
-                  child: Padding(
-                    padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
-                    child: ButtonFavorite(),
+                  const Align(
+                    alignment: Alignment.topRight,
+                    child: Padding(
+                      padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
+                      child: ButtonFavorite(),
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-          _CardContent(sight: sight),
-        ],
+            _CardContent(sight: sight),
+          ],
+        ),
       ),
     );
   }
@@ -81,26 +84,13 @@ class _CardContent extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          LayoutBuilder(
-            builder: (context, constraints) {
-              return ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxWidth: constraints.maxWidth / 2,
-                ),
-                child: Container(
-                  color: const Color.fromRGBO(196, 196, 196, 1),
-                  padding: const EdgeInsets.fromLTRB(3, 2, 3, 0),
-                  child: Text(
-                    sight.name,
-                    style: AppTextStyles.text.copyWith(
-                      color: AppColors.secondary,
-                    ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              );
-            },
+          Text(
+            sight.name,
+            style: AppTextStyles.text.copyWith(
+              color: AppColors.secondary,
+            ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
           ),
           const SizedBox(
             height: AppSizes.paddingSubtitleDivider,

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -81,13 +81,26 @@ class _CardContent extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            sight.name,
-            style: AppTextStyles.text.copyWith(
-              color: AppColors.secondary,
-            ),
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
+          LayoutBuilder(
+            builder: (context, constraints) {
+              return ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: constraints.maxWidth / 2,
+                ),
+                child: Container(
+                  color: const Color.fromRGBO(196, 196, 196, 1),
+                  padding: const EdgeInsets.fromLTRB(3, 2, 3, 0),
+                  child: Text(
+                    sight.name,
+                    style: AppTextStyles.text.copyWith(
+                      color: AppColors.secondary,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              );
+            },
           ),
           const SizedBox(
             height: AppSizes.paddingSubtitleDivider,

--- a/lib/ui/widgets/app_bar/app_bar_large_title.dart
+++ b/lib/ui/widgets/app_bar/app_bar_large_title.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/widgets/text/text_large_title.dart';
 
-/// AppBar для экранов списка
+/// AppBar для экрана списка
 class AppBarLargeTitle extends StatelessWidget implements PreferredSizeWidget {
   final String title;
 


### PR DESCRIPTION
- В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер виджета Text поменялся? После выполнения,  отрегулируйте размер текста согласно дизайну.
    **_- Text поменялся потому что ограничения идут сверху вниз, то есть ограничения от родителя ConstrainedBox_**

![sight_card_constrained_box](https://user-images.githubusercontent.com/7722321/167179949-a1b14b0a-d9d1-4c64-8e8c-63ae8440c9e6.png)    

- Добавьте отступ между между фотографиями и описанием с помощью SizedBox
    **_- Не понятно зачем SizedBox.  Сделано через Padding._**
    
- AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2
   **_- Что-то не так сделал? Отличaется от дизайна в Figma. :)_**
   
![sight_card_aspect_ratio](https://user-images.githubusercontent.com/7722321/167181012-9408677c-419e-4254-9adc-1749821389d8.png)

- Переверстать AppBar через наследника PreferredSizeWidget.