### PR TITLE
4.10 - Виджеты для отображения контента

### DIFF
--- a/lib/presets/colors/gradients.dart
+++ b/lib/presets/colors/gradients.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Градиенты приложения
+class AppGradients {
+  static const Gradient whiteImageGradient = LinearGradient(
+    colors: [
+      Color.fromRGBO(37, 40, 73, 1),
+      Color.fromRGBO(59, 62, 91, 0.08),
+    ],
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+  );
+
+  AppGradients._();
+}

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -1,10 +1,14 @@
-import 'package:flutter/cupertino.dart';
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/presets/colors/colors.dart';
+import 'package:places/presets/colors/gradients.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/button/button_favorite.dart';
+import 'package:places/ui/widgets/container/container_for_image_network.dart';
+import 'package:places/ui/widgets/container/container_with_opacity_for_images.dart';
 
 /// Карточка интересного место
 class SightCard extends StatelessWidget {
@@ -19,6 +23,7 @@ class SightCard extends StatelessWidget {
       aspectRatio: 3 / 2,
       child: Container(
         margin: margin,
+        clipBehavior: Clip.antiAlias,
         decoration: const BoxDecoration(
           color: AppColors.background,
           borderRadius: BorderRadius.all(
@@ -27,37 +32,33 @@ class SightCard extends StatelessWidget {
         ),
         child: Column(
           children: [
-            Container(
-              height: AppSizes.heightImageCard,
-              decoration: const BoxDecoration(
-                color: AppColors.whiteGreen,
-                borderRadius: BorderRadius.vertical(
-                  top: AppSizes.radiusNormal,
+            Stack(
+              children: [
+                ContainerForImageNetwork(
+                  url: sight.urls.first,
+                  height: AppSizes.heightImageCard,
                 ),
-              ),
-              child: Stack(
-                children: [
-                  Align(
-                    alignment: Alignment.topLeft,
-                    child: Padding(
-                      padding: const EdgeInsets.all(AppSizes.paddingCommon),
-                      child: Text(
-                        sight.type.name.toLowerCase(),
-                        style: AppTextStyles.smallBold.copyWith(
-                          color: AppColors.white,
-                        ),
+                const ContainerWithOpacityForImages(),
+                Align(
+                  alignment: Alignment.topLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.all(AppSizes.paddingCommon),
+                    child: Text(
+                      sight.type.name.toLowerCase(),
+                      style: AppTextStyles.smallBold.copyWith(
+                        color: AppColors.white,
                       ),
                     ),
                   ),
-                  const Align(
-                    alignment: Alignment.topRight,
-                    child: Padding(
-                      padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
-                      child: ButtonFavorite(),
-                    ),
+                ),
+                const Align(
+                  alignment: Alignment.topRight,
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(18, 19, 18, 18),
+                    child: ButtonFavorite(),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
             _CardContent(sight: sight),
           ],

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -1,14 +1,10 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/presets/colors/colors.dart';
-import 'package:places/presets/colors/gradients.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/button/button_favorite.dart';
 import 'package:places/ui/widgets/container/container_for_image_network.dart';
-import 'package:places/ui/widgets/container/container_with_opacity_for_images.dart';
 
 /// Карточка интересного место
 class SightCard extends StatelessWidget {
@@ -38,7 +34,7 @@ class SightCard extends StatelessWidget {
                   url: sight.urls.first,
                   height: AppSizes.heightImageCard,
                 ),
-                const ContainerWithOpacityForImages(),
+                // const ContainerWithOpacityForImages(),
                 Align(
                   alignment: Alignment.topLeft,
                   child: Padding(

--- a/lib/ui/screen/sight_details.dart
+++ b/lib/ui/screen/sight_details.dart
@@ -20,7 +20,9 @@ class SightDetails extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.white,
-      appBar: const AppBarSightDetails(),
+      appBar: AppBarSightDetails(
+        imageUrls: sight.urls,
+      ),
       body: SingleChildScrollView(
         child: Container(
           width: double.infinity,

--- a/lib/ui/widgets/app_bar/app_bar_sight_details.dart
+++ b/lib/ui/widgets/app_bar/app_bar_sight_details.dart
@@ -3,17 +3,18 @@ import 'package:flutter/services.dart';
 import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/widgets/button/button_top_navigation.dart';
+import 'package:places/ui/widgets/container/container_for_image_network.dart';
 
 /// AppBar для экранов списка
 class AppBarSightDetails extends StatelessWidget
     implements PreferredSizeWidget {
-  // TODO(me): изменить на картинку
-  final String? image;
+  final List<String> imageUrls;
 
   @override
   Size get preferredSize => const Size.fromHeight(AppSizes.heightAppBarImage);
 
-  const AppBarSightDetails({this.image, Key? key}) : super(key: key);
+  const AppBarSightDetails({required this.imageUrls, Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -21,8 +22,8 @@ class AppBarSightDetails extends StatelessWidget
       elevation: 0,
       toolbarHeight: AppSizes.heightAppBarImage,
       titleSpacing: 0,
+      backgroundColor: Colors.transparent,
       title: SizedBox(
-        width: double.infinity,
         height: AppSizes.heightAppBarImage,
         child: Stack(
           children: [
@@ -46,11 +47,11 @@ class AppBarSightDetails extends StatelessWidget
           ],
         ),
       ),
-      flexibleSpace: Container(
-        width: double.infinity,
-        color: AppColors.whiteGreen,
+      flexibleSpace: ContainerForImageNetwork(
+        url: imageUrls.first,
+        height: double.infinity,
       ),
-      systemOverlayStyle: SystemUiOverlayStyle.dark.copyWith(
+      systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
         statusBarColor: Colors.transparent,
       ),
     );

--- a/lib/ui/widgets/container/container_for_image_network.dart
+++ b/lib/ui/widgets/container/container_for_image_network.dart
@@ -1,35 +1,50 @@
 import 'package:flutter/material.dart';
 import 'package:places/presets/colors/colors.dart';
+import 'package:places/ui/widgets/container/container_with_opacity_for_images.dart';
 
 /// Контайнер для просмотра изображения по url
+///
+/// [withGradient] - наложение поверх изображения контайнер с градиентом и прозрачностью
 class ContainerForImageNetwork extends StatelessWidget {
   final String url;
   final double height;
+  final bool withGradient;
 
   const ContainerForImageNetwork({
     required this.url,
     required this.height,
+    this.withGradient = true,
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.center,
+    return SizedBox(
       height: height,
-      child: Image.network(
-        url,
-        fit: BoxFit.cover,
-        width: double.infinity,
-        loadingBuilder: (context, child, loadingProgress) {
-          if (loadingProgress == null) return child;
+      child: Stack(
+        children: [
+          SizedBox.expand(
+            child: Image.network(
+              url,
+              fit: BoxFit.cover,
+              loadingBuilder: (context, child, loadingProgress) {
+                if (loadingProgress == null) return child;
 
-          return CircularProgressIndicator(
-            color: AppColors.inactiveBlack.withOpacity(1),
-            backgroundColor: AppColors.background,
-            strokeWidth: 6,
-          );
-        },
+                return SizedBox.square(
+                  dimension: 40,
+                  child: Align(
+                    child: CircularProgressIndicator(
+                      color: AppColors.inactiveBlack.withOpacity(1),
+                      backgroundColor: AppColors.background,
+                      strokeWidth: 6,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          if (withGradient) const ContainerWithOpacityForImages(),
+        ],
       ),
     );
   }

--- a/lib/ui/widgets/container/container_for_image_network.dart
+++ b/lib/ui/widgets/container/container_for_image_network.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:places/presets/colors/colors.dart';
+
+/// Контайнер для просмотра изображения по url
+class ContainerForImageNetwork extends StatelessWidget {
+  final String url;
+  final double height;
+
+  const ContainerForImageNetwork({
+    required this.url,
+    required this.height,
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.center,
+      height: height,
+      child: Image.network(
+        url,
+        fit: BoxFit.cover,
+        width: double.infinity,
+        loadingBuilder: (context, child, loadingProgress) {
+          if (loadingProgress == null) return child;
+
+          return CircularProgressIndicator(
+            color: AppColors.inactiveBlack.withOpacity(1),
+            backgroundColor: AppColors.background,
+            strokeWidth: 6,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/container/container_with_opacity_for_images.dart
+++ b/lib/ui/widgets/container/container_with_opacity_for_images.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:places/presets/colors/gradients.dart';
-import 'package:places/presets/styles/app_sizes.dart';
 
 /// Контейнер для наложение поверх изображения с градиентом и прозрачностию
 class ContainerWithOpacityForImages extends StatelessWidget {
@@ -14,7 +13,7 @@ class ContainerWithOpacityForImages extends StatelessWidget {
     return Opacity(
       opacity: opacity,
       child: Container(
-        height: AppSizes.heightImageCard,
+        width: double.infinity,
         decoration: const BoxDecoration(
           gradient: AppGradients.whiteImageGradient,
         ),

--- a/lib/ui/widgets/container/container_with_opacity_for_images.dart
+++ b/lib/ui/widgets/container/container_with_opacity_for_images.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:places/presets/colors/gradients.dart';
+import 'package:places/presets/styles/app_sizes.dart';
+
+/// Контейнер для наложение поверх изображения с градиентом и прозрачностию
+class ContainerWithOpacityForImages extends StatelessWidget {
+  final double opacity;
+
+  const ContainerWithOpacityForImages({this.opacity = 0.4, Key? key})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: opacity,
+      child: Container(
+        height: AppSizes.heightImageCard,
+        decoration: const BoxDecoration(
+          gradient: AppGradients.whiteImageGradient,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### Загрузка изображений для карточек
  - Пользуясь моковыми данными, созданными в уроке 4.3, загрузите изображения для интересных мест для каждой карточки. После прохождения тем, связанных с сетевым взаимодействием и подключения приложения к API, вы замените моковые картинки на изображения из сервера. 
  - Задайте параметры растягивания изоборажения согласно дизайну
  - Во время загрузки отобразите лоадер.
  
![Screenshot_1652092543](https://user-images.githubusercontent.com/7722321/167414750-6326fe33-96e2-49c8-bd83-6a1360984a6c.png)

### Загрузка изображения для детализации места
  - Аналогичным образом, загрузите изображение интересного места на экран детализации.
  - Пока загрузите ту же самую фотографию, что использовалась в карточке. На текущий момент это будет одна фотография. После прохождения PageView, вы модифицируйте статичное фото в прокручиваемую фотогалерею, а после прохождения сетевых запросов добавите реальные фотографии из сервера.
  
![Screenshot_1652100306](https://user-images.githubusercontent.com/7722321/167415005-97145d85-a671-4640-922d-168e4aeb2b13.png)
![Screenshot_1652100343](https://user-images.githubusercontent.com/7722321/167415015-c7a0b4b2-665d-4904-bcc3-4d26a07dee38.png)
