### PR TITLE
4.16 - Работа со стилями и темами

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:places/presets/settings/settings.dart';
 import 'package:places/presets/strings/app_strings.dart';
+import 'package:places/ui/screen/res/themes.dart';
 import 'package:places/ui/screen/sight_list_screen.dart';
 
 void main() {
@@ -13,15 +14,23 @@ void main() {
   runApp(const App());
 }
 
-class App extends StatelessWidget {
+class App extends StatefulWidget {
   const App({Key? key}) : super(key: key);
 
   @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  final _darkMode = false;
+
+  @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       debugShowCheckedModeBanner: false,
+      theme: _darkMode ? AppThemes.darkTheme : AppThemes.lightTheme,
       title: AppStrings.appTitle,
-      home: SightListScreen(),
+      home: const SightListScreen(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,21 +14,15 @@ void main() {
   runApp(const App());
 }
 
-class App extends StatefulWidget {
+class App extends StatelessWidget {
   const App({Key? key}) : super(key: key);
-
-  @override
-  State<App> createState() => _AppState();
-}
-
-class _AppState extends State<App> {
-  final _darkMode = false;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: _darkMode ? AppThemes.darkTheme : AppThemes.lightTheme,
+      theme: AppThemes.lightTheme,
+      darkTheme: AppThemes.darkTheme,
       title: AppStrings.appTitle,
       home: const SightListScreen(),
     );

--- a/lib/presets/colors/colors.dart
+++ b/lib/presets/colors/colors.dart
@@ -22,9 +22,5 @@ class AppColors {
   static const blackDark = Color(0xff1A1A20);
   static const blackMain = Color(0xff21222C);
 
-  /// Светлая тема
-  static const lightScaffoldBackgroundColor = white;
-  static const lightDividerColor = inactiveBlack;
-
   AppColors._();
 }

--- a/lib/presets/colors/colors.dart
+++ b/lib/presets/colors/colors.dart
@@ -22,5 +22,9 @@ class AppColors {
   static const blackDark = Color(0xff1A1A20);
   static const blackMain = Color(0xff21222C);
 
+  /// Светлая тема
+  static const lightScaffoldBackgroundColor = white;
+  static const lightDividerColor = inactiveBlack;
+
   AppColors._();
 }

--- a/lib/presets/styles/app_sizes.dart
+++ b/lib/presets/styles/app_sizes.dart
@@ -19,6 +19,7 @@ class AppSizes {
   static const double paddingAppBarLargeTitle = 40;
   static const double paddingAppBarTopNavigation = 36;
   static const double paddingBtnNormal = 15;
+  static const double paddingBtnNormalWithIcon = 12;
   static const double paddingBtnSmall = 11;
   static const double paddingSpaceBetweenIconAndText = 10;
 

--- a/lib/ui/screen/res/color_schemes.dart
+++ b/lib/ui/screen/res/color_schemes.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:places/presets/colors/colors.dart';
+
+/// Схема цветов темы приложения
+extension AppColorScheme on ColorScheme {
+  Color? get customButton => brightness == Brightness.dark
+      ? AppColors.blackGreen
+      : AppColors.whiteGreen;
+
+  Color? get customWarning => brightness == Brightness.dark
+      ? AppColors.blackYellow
+      : AppColors.whiteYellow;
+
+  Color? get customMain =>
+      brightness == Brightness.dark ? AppColors.blackMain : AppColors.whiteMain;
+
+  Color? get customDark =>
+      brightness == Brightness.dark ? AppColors.blackDark : null;
+
+  Color? get customSecondary => AppColors.secondary;
+  Color? get customSecondary2 => AppColors.secondary2;
+  Color? get customInativeBlack => AppColors.inactiveBlack;
+}

--- a/lib/ui/screen/res/themes.dart
+++ b/lib/ui/screen/res/themes.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:places/presets/colors/colors.dart';
+import 'package:places/presets/styles/app_sizes.dart';
+import 'package:places/presets/styles/text_styles.dart';
+
+/// Темы для приложения
+class AppThemes {
+  /// светлая тема
+  // ignore: long-method
+  static ThemeData get lightTheme {
+    final base = ThemeData.light();
+
+    return base.copyWith(
+      backgroundColor: AppColors.background,
+      primaryColor: AppColors.white,
+      primaryColorLight: AppColors.background,
+      primaryColorDark: AppColors.whiteMain,
+      colorScheme: base.colorScheme.copyWith(
+        background: AppColors.inactiveBlack,
+        primary: AppColors.whiteMain,
+        onPrimary: AppColors.white,
+        secondary: AppColors.secondary,
+        secondaryContainer: AppColors.secondary2,
+        tertiary: AppColors.whiteGreen,
+        tertiaryContainer: AppColors.whiteYellow,
+        error: AppColors.whiteRed,
+      ),
+      errorColor: AppColors.whiteRed,
+      scaffoldBackgroundColor: AppColors.lightScaffoldBackgroundColor,
+      dividerColor: AppColors.lightDividerColor,
+      disabledColor: AppColors.inactiveBlack,
+      cardColor: AppColors.background,
+      iconTheme: const IconThemeData(
+        color: AppColors.white,
+        size: 24,
+      ),
+      textTheme: base.textTheme.copyWith(
+        headline6: AppTextStyles.text.copyWith(color: AppColors.secondary),
+        headline5: AppTextStyles.subtitle.copyWith(color: AppColors.whiteMain),
+        headline4: AppTextStyles.title.copyWith(color: AppColors.secondary),
+        headline3:
+            AppTextStyles.largeTitle.copyWith(color: AppColors.secondary),
+        subtitle1: AppTextStyles.smallBold.copyWith(color: AppColors.secondary),
+        subtitle2: AppTextStyles.small.copyWith(color: AppColors.secondary2),
+        bodyText1: AppTextStyles.text.copyWith(color: AppColors.secondary),
+        bodyText2: AppTextStyles.small.copyWith(color: AppColors.secondary),
+        caption: AppTextStyles.superSmall,
+        button: AppTextStyles.button,
+      ),
+      appBarTheme: base.appBarTheme.copyWith(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        systemOverlayStyle: SystemUiOverlayStyle.dark.copyWith(
+          statusBarColor: Colors.transparent,
+        ),
+      ),
+      tabBarTheme: base.tabBarTheme.copyWith(
+        labelStyle: AppTextStyles.smallBold,
+        labelColor: AppColors.white,
+        unselectedLabelColor: AppColors.inactiveBlack,
+        indicator: const BoxDecoration(
+          color: AppColors.whiteMain,
+          borderRadius: BorderRadius.all(
+            AppSizes.radiusBtnSwitch,
+          ),
+        ),
+        indicatorSize: TabBarIndicatorSize.tab,
+      ),
+      bottomNavigationBarTheme: base.bottomNavigationBarTheme.copyWith(
+        elevation: 0,
+        backgroundColor: AppColors.lightScaffoldBackgroundColor,
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        selectedItemColor: AppColors.whiteMain,
+        unselectedItemColor: AppColors.secondary,
+        type: BottomNavigationBarType.fixed,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(
+            AppColors.whiteGreen,
+          ),
+          foregroundColor: MaterialStateProperty.all(
+            AppColors.white,
+          ),
+          elevation: MaterialStateProperty.all(0),
+          padding: MaterialStateProperty.all(
+            const EdgeInsets.all(
+              AppSizes.paddingBtnNormal,
+            ),
+          ),
+          shape: MaterialStateProperty.all(
+            const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(AppSizes.radiusBtnNormal),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// темная тема
+  // ignore: long-method
+  static ThemeData get darkTheme {
+    final base = ThemeData.dark();
+
+    return base.copyWith(
+      backgroundColor: AppColors.blackDark,
+      primaryColor: AppColors.blackMain,
+      primaryColorLight: AppColors.background,
+      primaryColorDark: AppColors.white,
+      colorScheme: base.colorScheme.copyWith(
+        background: AppColors.inactiveBlack,
+        primary: AppColors.blackMain,
+        onPrimary: AppColors.white,
+        secondary: AppColors.secondary,
+        secondaryContainer: AppColors.secondary2,
+        tertiary: AppColors.blackGreen,
+        tertiaryContainer: AppColors.blackYellow,
+        error: AppColors.blackRed,
+      ),
+      errorColor: AppColors.blackRed,
+      scaffoldBackgroundColor: AppColors.blackMain,
+      dividerColor: AppColors.secondary2,
+      disabledColor: AppColors.inactiveBlack,
+      cardColor: AppColors.blackDark,
+      iconTheme: const IconThemeData(
+        color: AppColors.white,
+        size: 24,
+      ),
+      textTheme: base.textTheme.copyWith(
+        headline6: AppTextStyles.text.copyWith(color: AppColors.white),
+        headline5: AppTextStyles.subtitle.copyWith(color: AppColors.white),
+        headline4: AppTextStyles.title.copyWith(color: AppColors.white),
+        headline3: AppTextStyles.largeTitle.copyWith(color: AppColors.white),
+        subtitle1:
+            AppTextStyles.smallBold.copyWith(color: AppColors.secondary2),
+        subtitle2: AppTextStyles.small.copyWith(color: AppColors.secondary2),
+        bodyText1: AppTextStyles.text.copyWith(color: AppColors.white),
+        bodyText2: AppTextStyles.small.copyWith(color: AppColors.white),
+        caption: AppTextStyles.superSmall,
+        button: AppTextStyles.button,
+      ),
+      appBarTheme: base.appBarTheme.copyWith(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
+          statusBarColor: Colors.transparent,
+        ),
+      ),
+      tabBarTheme: base.tabBarTheme.copyWith(
+        labelStyle: AppTextStyles.smallBold,
+        labelColor: AppColors.secondary,
+        unselectedLabelColor: AppColors.secondary2,
+        indicator: const BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.all(
+            AppSizes.radiusBtnSwitch,
+          ),
+        ),
+        indicatorSize: TabBarIndicatorSize.tab,
+      ),
+      bottomNavigationBarTheme: base.bottomNavigationBarTheme.copyWith(
+        elevation: 0,
+        backgroundColor: AppColors.blackMain,
+        showSelectedLabels: false,
+        showUnselectedLabels: false,
+        selectedItemColor: AppColors.white,
+        unselectedItemColor: AppColors.background,
+        type: BottomNavigationBarType.fixed,
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(
+            AppColors.blackGreen,
+          ),
+          foregroundColor: MaterialStateProperty.all(
+            AppColors.white,
+          ),
+          elevation: MaterialStateProperty.all(0),
+          padding: MaterialStateProperty.all(
+            const EdgeInsets.all(
+              AppSizes.paddingBtnNormal,
+            ),
+          ),
+          shape: MaterialStateProperty.all(
+            const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(AppSizes.radiusBtnNormal),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  AppThemes._();
+}

--- a/lib/ui/screen/res/themes.dart
+++ b/lib/ui/screen/res/themes.dart
@@ -28,8 +28,8 @@ class AppThemes {
         error: AppColors.whiteRed,
       ),
       errorColor: AppColors.whiteRed,
-      scaffoldBackgroundColor: AppColors.lightScaffoldBackgroundColor,
-      dividerColor: AppColors.lightDividerColor,
+      scaffoldBackgroundColor: AppColors.white,
+      dividerColor: AppColors.inactiveBlack,
       disabledColor: AppColors.inactiveBlack,
       cardColor: AppColors.background,
       iconTheme: const IconThemeData(
@@ -70,7 +70,7 @@ class AppThemes {
       ),
       bottomNavigationBarTheme: base.bottomNavigationBarTheme.copyWith(
         elevation: 0,
-        backgroundColor: AppColors.lightScaffoldBackgroundColor,
+        backgroundColor: AppColors.white,
         showSelectedLabels: false,
         showUnselectedLabels: false,
         selectedItemColor: AppColors.whiteMain,

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
-import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/button/button_favorite.dart';
 import 'package:places/ui/widgets/container/container_for_image_network.dart';
 
@@ -15,14 +13,16 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return AspectRatio(
       aspectRatio: 3 / 2,
       child: Container(
         margin: margin,
         clipBehavior: Clip.antiAlias,
-        decoration: const BoxDecoration(
-          color: AppColors.background,
-          borderRadius: BorderRadius.all(
+        decoration: BoxDecoration(
+          color: theme.cardColor,
+          borderRadius: const BorderRadius.all(
             AppSizes.radiusNormal,
           ),
         ),
@@ -41,8 +41,8 @@ class SightCard extends StatelessWidget {
                     padding: const EdgeInsets.all(AppSizes.paddingCommon),
                     child: Text(
                       sight.type.name.toLowerCase(),
-                      style: AppTextStyles.smallBold.copyWith(
-                        color: AppColors.white,
+                      style: theme.textTheme.subtitle1!.copyWith(
+                        color: theme.colorScheme.onPrimary,
                       ),
                     ),
                   ),
@@ -74,6 +74,8 @@ class _CardContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Padding(
       padding: const EdgeInsets.all(
         AppSizes.paddingCommon,
@@ -83,9 +85,7 @@ class _CardContent extends StatelessWidget {
         children: [
           Text(
             sight.name,
-            style: AppTextStyles.text.copyWith(
-              color: AppColors.secondary,
-            ),
+            style: theme.textTheme.headline6,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
@@ -94,9 +94,7 @@ class _CardContent extends StatelessWidget {
           ),
           Text(
             sight.details,
-            style: AppTextStyles.small.copyWith(
-              color: AppColors.secondary2,
-            ),
+            style: theme.textTheme.subtitle2,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -41,7 +41,7 @@ class SightCard extends StatelessWidget {
                     padding: const EdgeInsets.all(AppSizes.paddingCommon),
                     child: Text(
                       sight.type.name.toLowerCase(),
-                      style: theme.textTheme.subtitle1!.copyWith(
+                      style: theme.textTheme.subtitle1?.copyWith(
                         color: theme.colorScheme.onPrimary,
                       ),
                     ),

--- a/lib/ui/screen/sight_details.dart
+++ b/lib/ui/screen/sight_details.dart
@@ -1,15 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:places/domain/sight.dart';
 import 'package:places/presets/assets/icons.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/strings/app_strings.dart';
 import 'package:places/presets/styles/app_sizes.dart';
-import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/app_bar/app_bar_sight_details.dart';
 import 'package:places/ui/widgets/button/button_normal.dart';
 import 'package:places/ui/widgets/button/button_small_with_status.dart';
 import 'package:places/ui/widgets/divider/divider_default.dart';
-import 'package:places/ui/widgets/icon/icon_svg.dart';
 
 /// Экран подробной информации о месте
 class SightDetails extends StatelessWidget {
@@ -19,8 +16,9 @@ class SightDetails extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Scaffold(
-      backgroundColor: AppColors.white,
       appBar: AppBarSightDetails(
         imageUrls: sight.urls,
       ),
@@ -36,9 +34,7 @@ class SightDetails extends StatelessWidget {
             children: [
               Text(
                 sight.name,
-                style: AppTextStyles.title.copyWith(
-                  color: AppColors.secondary,
-                ),
+                style: theme.textTheme.headline4,
               ),
               const SizedBox(
                 height: AppSizes.paddingSubtitleDivider,
@@ -47,17 +43,17 @@ class SightDetails extends StatelessWidget {
                 children: [
                   Text(
                     sight.type.name.toLowerCase(),
-                    style: AppTextStyles.smallBold.copyWith(
-                      color: AppColors.secondary,
-                    ),
+                    style: theme.textTheme.subtitle1,
                   ),
                   const SizedBox(
                     width: AppSizes.paddingCommon,
                   ),
                   Text(
                     '${AppStrings.closedUntil.toLowerCase()} 09:00',
-                    style: AppTextStyles.small.copyWith(
-                      color: AppColors.secondary2,
+                    style: theme.textTheme.subtitle2!.copyWith(
+                      color: theme.brightness == Brightness.dark
+                          ? theme.colorScheme.background
+                          : null,
                     ),
                   ),
                 ],
@@ -67,18 +63,14 @@ class SightDetails extends StatelessWidget {
               ),
               Text(
                 sight.details,
-                style: AppTextStyles.small.copyWith(
-                  color: AppColors.secondary,
-                ),
+                style: theme.textTheme.bodyText2,
               ),
               const SizedBox(
                 height: AppSizes.paddingDetailContentDivider,
               ),
               ButtonNormal(
                 text: AppStrings.buildRoute.toUpperCase(),
-                icon: const IconSvg(
-                  icon: AppIcons.iconGo,
-                ),
+                icon: AppIcons.iconGo,
               ),
               const SizedBox(
                 height: AppSizes.paddingCommon,

--- a/lib/ui/screen/sight_details.dart
+++ b/lib/ui/screen/sight_details.dart
@@ -50,7 +50,7 @@ class SightDetails extends StatelessWidget {
                   ),
                   Text(
                     '${AppStrings.closedUntil.toLowerCase()} 09:00',
-                    style: theme.textTheme.subtitle2!.copyWith(
+                    style: theme.textTheme.subtitle2?.copyWith(
                       color: theme.brightness == Brightness.dark
                           ? theme.colorScheme.background
                           : null,

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:places/mocks.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/strings/app_strings.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/screen/sight_card.dart';
@@ -19,7 +18,6 @@ class _SightListScreenState extends State<SightListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: AppColors.white,
       resizeToAvoidBottomInset: false,
       appBar: const AppBarLargeTitle(title: AppStrings.scrTitleSightListScreen),
       body: SingleChildScrollView(

--- a/lib/ui/screen/visiting_card.dart
+++ b/lib/ui/screen/visiting_card.dart
@@ -2,11 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:places/domain/favorite_sight.dart';
 import 'package:places/presets/assets/icons.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/settings/settings.dart';
 import 'package:places/presets/strings/app_strings.dart';
 import 'package:places/presets/styles/app_sizes.dart';
-import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/button/button_icon_svg.dart';
 import 'package:places/ui/widgets/container/container_for_image_network.dart';
 
@@ -20,14 +18,16 @@ class FavoriteSightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return AspectRatio(
       aspectRatio: 3 / 2,
       child: Container(
         margin: margin,
         clipBehavior: Clip.antiAlias,
-        decoration: const BoxDecoration(
-          color: AppColors.background,
-          borderRadius: BorderRadius.all(
+        decoration: BoxDecoration(
+          color: theme.backgroundColor,
+          borderRadius: const BorderRadius.all(
             AppSizes.radiusNormal,
           ),
         ),
@@ -45,8 +45,8 @@ class FavoriteSightCard extends StatelessWidget {
                     padding: const EdgeInsets.all(AppSizes.paddingCommon),
                     child: Text(
                       favoriteSight.sight.type.name.toLowerCase(),
-                      style: AppTextStyles.smallBold.copyWith(
-                        color: AppColors.white,
+                      style: theme.textTheme.subtitle1?.copyWith(
+                        color: theme.colorScheme.onPrimary,
                       ),
                     ),
                   ),
@@ -82,14 +82,12 @@ class _FavoriteCardButtons extends StatelessWidget {
           icon: favoriteSight.visited
               ? AppIcons.iconShare
               : AppIcons.iconCalendar,
-          color: AppColors.white,
         ),
         const SizedBox(
           width: AppSizes.paddingCommon,
         ),
         const ButtonIconSvg(
           icon: AppIcons.iconClose,
-          color: AppColors.white,
         ),
       ],
     );
@@ -106,6 +104,8 @@ class _CardContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return Padding(
       padding: const EdgeInsets.all(
         AppSizes.paddingCommon,
@@ -115,9 +115,7 @@ class _CardContent extends StatelessWidget {
         children: [
           Text(
             favoriteSight.sight.name,
-            style: AppTextStyles.text.copyWith(
-              color: AppColors.secondary,
-            ),
+            style: theme.textTheme.headline6,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
           ),
@@ -132,10 +130,10 @@ class _CardContent extends StatelessWidget {
                   : '${favoriteSight.visited ? AppStrings.planeWasReached : AppStrings.planedFor} ${DateFormat(AppSettings.dateFormatAbrMonth).format(
                       favoriteSight.date!,
                     )}',
-              style: AppTextStyles.small.copyWith(
+              style: theme.textTheme.subtitle2?.copyWith(
                 color: favoriteSight.visited
-                    ? AppColors.secondary2
-                    : AppColors.whiteGreen,
+                    ? theme.colorScheme.secondaryContainer
+                    : theme.colorScheme.tertiary,
               ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
@@ -146,9 +144,7 @@ class _CardContent extends StatelessWidget {
           ),
           Text(
             '${AppStrings.closedUntil} 09:00',
-            style: AppTextStyles.small.copyWith(
-              color: AppColors.secondary2,
-            ),
+            style: theme.textTheme.subtitle2,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
           ),

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -3,7 +3,6 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:places/domain/favorite_sight.dart';
 import 'package:places/mocks.dart';
 import 'package:places/presets/assets/icons.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/settings/settings.dart';
 import 'package:places/presets/strings/app_strings.dart';
 import 'package:places/presets/styles/app_sizes.dart';
@@ -29,7 +28,7 @@ class VisitingScreen extends StatelessWidget {
     return DefaultTabController(
       length: _tabsTitles.length,
       child: Scaffold(
-        backgroundColor: AppColors.white,
+        backgroundColor: Theme.of(context).primaryColor,
         appBar: AppBarStandard(
           title: AppStrings.srcTitleFavoriteScreen,
           tabsTitles: _tabsTitles,

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -28,7 +28,6 @@ class VisitingScreen extends StatelessWidget {
     return DefaultTabController(
       length: _tabsTitles.length,
       child: Scaffold(
-        backgroundColor: Theme.of(context).primaryColor,
         appBar: AppBarStandard(
           title: AppStrings.srcTitleFavoriteScreen,
           tabsTitles: _tabsTitles,

--- a/lib/ui/widgets/app_bar/app_bar_large_title.dart
+++ b/lib/ui/widgets/app_bar/app_bar_large_title.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/widgets/text/text_large_title.dart';
 
@@ -16,12 +15,7 @@ class AppBarLargeTitle extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      backgroundColor: Colors.transparent,
       toolbarHeight: AppSizes.heightAppBarLargeTitle,
-      elevation: 0,
-      systemOverlayStyle: SystemUiOverlayStyle.dark.copyWith(
-        statusBarColor: Colors.transparent,
-      ),
       titleSpacing: 0,
       title: Container(
         width: double.infinity,

--- a/lib/ui/widgets/app_bar/app_bar_sight_details.dart
+++ b/lib/ui/widgets/app_bar/app_bar_sight_details.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/widgets/button/button_top_navigation.dart';
 import 'package:places/ui/widgets/container/container_for_image_network.dart';
@@ -18,11 +17,11 @@ class AppBarSightDetails extends StatelessWidget
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
     return AppBar(
-      elevation: 0,
       toolbarHeight: AppSizes.heightAppBarImage,
       titleSpacing: 0,
-      backgroundColor: Colors.transparent,
       title: SizedBox(
         height: AppSizes.heightAppBarImage,
         child: Stack(
@@ -38,9 +37,10 @@ class AppBarSightDetails extends StatelessWidget
               child: Container(
                 width: 152,
                 height: 8,
-                decoration: const BoxDecoration(
-                  color: AppColors.whiteMain,
-                  borderRadius: BorderRadius.all(AppSizes.radiusBtnImageSlider),
+                decoration: BoxDecoration(
+                  color: theme.primaryColorDark,
+                  borderRadius:
+                      const BorderRadius.all(AppSizes.radiusBtnImageSlider),
                 ),
               ),
             ),

--- a/lib/ui/widgets/app_bar/app_bar_standard.dart
+++ b/lib/ui/widgets/app_bar/app_bar_standard.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
-import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/tab_bar/tab_bar_standard.dart';
 
 /// AppBar для экранов списка
@@ -42,16 +39,12 @@ class AppBarStandard extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      elevation: 0,
       toolbarHeight: AppSizes.heightAppBar,
       titleSpacing: AppSizes.paddingCommon,
       centerTitle: true,
-      backgroundColor: Colors.transparent,
       title: Text(
         title,
-        style: AppTextStyles.subtitle.copyWith(
-          color: AppColors.whiteMain,
-        ),
+        style: Theme.of(context).textTheme.headline5,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
       ),
@@ -68,9 +61,6 @@ class AppBarStandard extends StatelessWidget implements PreferredSizeWidget {
           ],
         ),
         preferredSize: Size.fromHeight(_bottomPreferredSize),
-      ),
-      systemOverlayStyle: SystemUiOverlayStyle.dark.copyWith(
-        statusBarColor: Colors.transparent,
       ),
     );
   }

--- a/lib/ui/widgets/button/button_normal.dart
+++ b/lib/ui/widgets/button/button_normal.dart
@@ -21,7 +21,7 @@ class ButtonNormal extends StatelessWidget {
     final theme = Theme.of(context);
     final buttonStyle = theme.elevatedButtonTheme.style;
     final textIconColor = foregroundColor ??
-        buttonStyle?.foregroundColor!.resolve({MaterialState.selected});
+        buttonStyle?.foregroundColor?.resolve({MaterialState.selected});
 
     return ElevatedButton(
       style: buttonStyle?.copyWith(
@@ -42,7 +42,7 @@ class ButtonNormal extends StatelessWidget {
             ),
           Text(
             text,
-            style: theme.textTheme.button!.copyWith(
+            style: theme.textTheme.button?.copyWith(
               color: textIconColor,
             ),
           ),

--- a/lib/ui/widgets/button/button_normal.dart
+++ b/lib/ui/widgets/button/button_normal.dart
@@ -1,51 +1,67 @@
 import 'package:flutter/material.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
-import 'package:places/presets/styles/text_styles.dart';
+import 'package:places/ui/widgets/icon/icon_svg.dart';
 
 /// Стандартая кнопка приложения
 class ButtonNormal extends StatelessWidget {
   final String text;
-  final Color? textColor;
-  final Color? backgroundColor;
-  final Widget? icon;
+  final Color? foregroundColor;
+
+  final String? icon;
 
   const ButtonNormal({
     required this.text,
-    this.textColor,
-    this.backgroundColor,
+    this.foregroundColor,
     this.icon,
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(
-        AppSizes.paddingBtnNormal,
+    final theme = Theme.of(context);
+    final buttonStyle = theme.elevatedButtonTheme.style;
+    final textIconColor = foregroundColor ??
+        buttonStyle?.foregroundColor!.resolve({MaterialState.selected});
+
+    return ElevatedButton(
+      style: buttonStyle?.copyWith(
+        padding: _paddingButton(buttonStyle),
       ),
-      decoration: BoxDecoration(
-        color: backgroundColor ?? AppColors.whiteGreen,
-        borderRadius: const BorderRadius.all(
-          AppSizes.radiusBtnNormal,
-        ),
-      ),
+      onPressed: () {},
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          if (icon != null) icon!,
+          if (icon != null)
+            IconSvg(
+              icon: icon!,
+              color: textIconColor,
+            ),
           if (icon != null)
             const SizedBox(
               width: AppSizes.paddingSpaceBetweenIconAndText,
             ),
           Text(
             text,
-            style: AppTextStyles.button.copyWith(
-              color: textColor ?? AppColors.white,
+            style: theme.textTheme.button!.copyWith(
+              color: textIconColor,
             ),
           ),
         ],
       ),
     );
+  }
+
+  MaterialStateProperty<EdgeInsetsGeometry?>? _paddingButton(
+    ButtonStyle? buttonStyle,
+  ) {
+    if (icon != null) {
+      return MaterialStateProperty.all(
+        const EdgeInsets.all(
+          AppSizes.paddingBtnNormalWithIcon,
+        ),
+      );
+    }
+
+    return buttonStyle?.padding;
   }
 }

--- a/lib/ui/widgets/button/button_small_with_status.dart
+++ b/lib/ui/widgets/button/button_small_with_status.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/presets/styles/text_styles.dart';
 import 'package:places/ui/widgets/icon/icon_svg.dart';
@@ -19,9 +18,14 @@ class ButtonSmallWithStatus extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final disabledColor = theme.disabledColor;
+    final enabledColor = theme.brightness == Brightness.dark
+        ? theme.colorScheme.onPrimary
+        : theme.colorScheme.secondary;
+
     // цвет в зависимости от статуса
-    final colorByStatus =
-        disabled ? AppColors.inactiveBlack : AppColors.secondary;
+    final colorByStatus = disabled ? disabledColor : enabledColor;
 
     // иконка кнопки
     IconSvg? iconSvg;

--- a/lib/ui/widgets/button/button_top_navigation.dart
+++ b/lib/ui/widgets/button/button_top_navigation.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:places/presets/assets/icons.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/widgets/icon/icon_svg.dart';
 
@@ -12,18 +11,25 @@ class ButtonTopNavigation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: AppSizes.sizeBtnTopNavigation.width,
-      height: AppSizes.sizeBtnTopNavigation.height,
-      decoration: const BoxDecoration(
-        color: AppColors.background,
-        borderRadius: BorderRadius.all(
-          AppSizes.radiusBtnTopNavigation,
+    final theme = Theme.of(context);
+
+    return IconButton(
+      onPressed: () {},
+      padding: EdgeInsets.zero,
+      constraints: BoxConstraints.tight(AppSizes.sizeBtnTopNavigation),
+      icon: Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: BoxDecoration(
+          color: theme.primaryColor,
+          borderRadius: const BorderRadius.all(
+            AppSizes.radiusBtnTopNavigation,
+          ),
         ),
-      ),
-      child: const IconSvg(
-        icon: AppIcons.iconArrow,
-        color: AppColors.whiteMain,
+        child: IconSvg(
+          icon: AppIcons.iconArrow,
+          color: theme.primaryColorDark,
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/divider/divider_default.dart
+++ b/lib/ui/widgets/divider/divider_default.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 
 class DividerDefault extends StatelessWidget {
@@ -9,7 +8,8 @@ class DividerDefault extends StatelessWidget {
   Widget build(BuildContext context) {
     return Divider(
       height: AppSizes.paddingCommon,
-      color: AppColors.inactiveBlack.withOpacity(0.24),
+      color: Theme.of(context).dividerColor.withOpacity(0.24),
+      thickness: 0.8,
     );
   }
 }

--- a/lib/ui/widgets/icon/icon_svg.dart
+++ b/lib/ui/widgets/icon/icon_svg.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:places/presets/colors/colors.dart';
-import 'package:places/presets/styles/app_sizes.dart';
 
 /// Svg иконка
 class IconSvg extends StatelessWidget {
@@ -11,18 +9,20 @@ class IconSvg extends StatelessWidget {
 
   const IconSvg({
     required this.icon,
-    this.size = AppSizes.sizeIcon,
-    this.color = AppColors.white,
+    this.size,
+    this.color,
     Key? key,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final iconTheme = Theme.of(context).iconTheme;
+
     return SvgPicture.asset(
       icon,
-      width: size?.width,
-      height: size?.height,
-      color: color,
+      width: size != null ? size!.width : iconTheme.size,
+      height: size != null ? size!.height : iconTheme.size,
+      color: color ?? iconTheme.color,
     );
   }
 }

--- a/lib/ui/widgets/navigation_bar/bottom_navigation_view.dart
+++ b/lib/ui/widgets/navigation_bar/bottom_navigation_view.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:places/presets/assets/icons.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/strings/app_strings.dart';
 import 'package:places/ui/widgets/icon/icon_svg.dart';
 
@@ -15,36 +14,34 @@ class BottomNavigationView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final navBarTheme = theme.bottomNavigationBarTheme;
+
     return DecoratedBox(
       decoration: BoxDecoration(
         boxShadow: [
           BoxShadow(
-            color: AppColors.inactiveBlack.withOpacity(0.56),
+            color: theme.dividerColor.withOpacity(0.56),
             blurRadius: 0.8,
           ),
         ],
       ),
       child: BottomNavigationBar(
-        elevation: 0,
-        showSelectedLabels: false,
-        showUnselectedLabels: false,
         currentIndex: currentIndex,
-        type: BottomNavigationBarType.fixed,
-        backgroundColor: AppColors.white,
         items: [
           BottomNavigationBarItem(
             label: AppStrings.appEmptyString,
             icon: IconSvg(
               icon:
                   currentIndex == 0 ? AppIcons.menuListFull : AppIcons.menuList,
-              color: _iconColor(currentIndex == 0),
+              color: _iconColor(currentIndex == 0, navBarTheme),
             ),
           ),
           BottomNavigationBarItem(
             label: AppStrings.appEmptyString,
             icon: IconSvg(
               icon: currentIndex == 1 ? AppIcons.menuMapFull : AppIcons.menuMap,
-              color: _iconColor(currentIndex == 1),
+              color: _iconColor(currentIndex == 1, navBarTheme),
             ),
           ),
           BottomNavigationBarItem(
@@ -53,7 +50,7 @@ class BottomNavigationView extends StatelessWidget {
               icon: currentIndex == 2
                   ? AppIcons.menuHeartFull
                   : AppIcons.menuHeart,
-              color: _iconColor(currentIndex == 2),
+              color: _iconColor(currentIndex == 2, navBarTheme),
             ),
           ),
           BottomNavigationBarItem(
@@ -62,7 +59,7 @@ class BottomNavigationView extends StatelessWidget {
               icon: currentIndex == 3
                   ? AppIcons.menuSettingsFull
                   : AppIcons.menuSettings,
-              color: _iconColor(currentIndex == 3),
+              color: _iconColor(currentIndex == 3, navBarTheme),
             ),
           ),
         ],
@@ -70,7 +67,7 @@ class BottomNavigationView extends StatelessWidget {
     );
   }
 
-  Color _iconColor(bool getMainColor) {
-    return getMainColor ? AppColors.whiteMain : AppColors.secondary;
+  Color _iconColor(bool getMainColor, BottomNavigationBarThemeData theme) {
+    return getMainColor ? theme.selectedItemColor! : theme.unselectedItemColor!;
   }
 }

--- a/lib/ui/widgets/tab_bar/tab_bar_standard.dart
+++ b/lib/ui/widgets/tab_bar/tab_bar_standard.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:places/presets/colors/colors.dart';
 import 'package:places/presets/styles/app_sizes.dart';
-import 'package:places/presets/styles/text_styles.dart';
 
 /// Стандартный TabBar
 class TabBarStandard extends StatelessWidget {
@@ -21,23 +19,13 @@ class TabBarStandard extends StatelessWidget {
       ),
       child: Container(
         height: AppSizes.heightTabStandard,
-        decoration: const BoxDecoration(
-          color: AppColors.background,
-          borderRadius: BorderRadius.all(
+        decoration: BoxDecoration(
+          color: Theme.of(context).backgroundColor,
+          borderRadius: const BorderRadius.all(
             AppSizes.radiusBtnSwitch,
           ),
         ),
         child: TabBar(
-          labelStyle: AppTextStyles.smallBold,
-          labelColor: AppColors.white,
-          unselectedLabelColor: AppColors.inactiveBlack,
-          indicator: const BoxDecoration(
-            color: AppColors.whiteMain,
-            borderRadius: BorderRadius.all(
-              AppSizes.radiusBtnSwitch,
-            ),
-          ),
-          indicatorSize: TabBarIndicatorSize.tab,
           tabs: tabsTitles
               .map(
                 (title) => Tab(

--- a/lib/ui/widgets/text/text_large_title.dart
+++ b/lib/ui/widgets/text/text_large_title.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:places/presets/colors/colors.dart';
-import 'package:places/presets/styles/text_styles.dart';
 
 /// Text для большого заголовка
 class TextLargeTitle extends StatelessWidget {
@@ -11,9 +9,7 @@ class TextLargeTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       data,
-      style: AppTextStyles.largeTitle.copyWith(
-        color: AppColors.secondary,
-      ),
+      style: Theme.of(context).textTheme.headline3,
       textAlign: TextAlign.left,
       maxLines: 2,
       overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
### Настройка темной и светлой темы
  1) Создайте в папке **screens** новую папку **res**. В папке **res** создайте файл с именем **themes.dart**.
  2) В **themes.dart** реализуйте темную и светлую тему согласно дизайну. 
  3) По умолчанию должна стоять светлая тема с переключением на темную. На текущий момент тема не будет сохраняться при выходе из приложения, когда пройдете хранение данных, реализуете сохранение темы.
  4) Темы обязательны для экранов "Список интересных мест", "Хочу посетить/посещенные места", "Детализация места". Для остальных экранов переключение тем по желанию.
  5) Прикрепите тему к виджету MaterialApp
  
![light_SightListScreen](https://user-images.githubusercontent.com/7722321/169133232-da49a3d0-c881-43d1-afba-f250095e9284.png)
![dark_SightListScreen](https://user-images.githubusercontent.com/7722321/169133436-80643a0d-fbc1-49c9-aa6c-ac3ef338bc2a.png)
![light_SightDetails](https://user-images.githubusercontent.com/7722321/169133644-4acc14ec-9c5d-48db-a1a4-e0fbfeb0fbb7.png)
![dark_SightDetails](https://user-images.githubusercontent.com/7722321/169133746-dfed5715-5740-4f07-9fe5-8ea76a6339ed.png)
![light_VisitingScreen](https://user-images.githubusercontent.com/7722321/169133830-43fecd49-0ec8-42d0-97cd-b935154ad8f3.png)
![dark_VisitingScreen](https://user-images.githubusercontent.com/7722321/169133924-0ffb5b52-fe01-4df9-b7e8-d5c5dc75ace7.png)
