### PR TITLE
6.4 - PageView

### DIFF
--- a/lib/presets/assets/icons.dart
+++ b/lib/presets/assets/icons.dart
@@ -9,6 +9,11 @@ class AppIcons {
   static const String emptyPageMap = '$_path/empty_pages/map.svg';
   static const String emptyPageSearch = '$_path/empty_pages/search.svg';
 
+  // иконки страниц онбординга
+  static const String onBoardPageWelcome = '$_path/tutorial/way_indicator.svg';
+  static const String onBoardPageCreateRoute = '$_path/tutorial/travel_bag.svg';
+  static const String onBoardPageAddSights = '$_path/tutorial/add.svg';
+
   // иконки меню
   static const String menuHeart = '$_path/menu/heart.svg';
   static const String menuHeartFull = '$_path/menu/heart_full.svg';

--- a/lib/presets/strings/app_strings.dart
+++ b/lib/presets/strings/app_strings.dart
@@ -31,6 +31,8 @@ class AppStrings {
   static const String delete = 'Удалить';
   static const String newSight = 'Новое место';
   static const String foundNothing = 'Ничего не найдено.';
+  static const String skip = 'Пропустить';
+  static const String toTheStart = 'На старт';
 
   /// Строки настройки
   static const String lightTheme = 'Светлая тема';
@@ -44,6 +46,19 @@ class AppStrings {
       'Завершите маршрут,\nчтобы место попало сюда.';
   static const String emptyPageFoundNothing =
       'Попробуйте изменить параметры\nпоиска';
+
+  static const String onBoardPageWelcome = 'Добро пожаловать\nв Путеводитель';
+  static const String onBoardPageCreateRoute =
+      'Построй маршрут\nи отправляйся в путь';
+  static const String onBoardPageAddSights =
+      'Добавляй места,\nкоторые нашёл сам';
+
+  static const String onBoardPageWelcomeDescription =
+      'Ищи новые локации и сохраняй\nсамые любимые.';
+  static const String onBoardPageCreateRouteDescription =
+      'Достигай цели максимально\nбыстро и комфортно.';
+  static const String onBoardPageAddSightsDescription =
+      'Делись самыми интересными\nи помоги нам стать лучше!';
 
   static const String categories = 'Категории';
 

--- a/lib/ui/screen/onboarding_screen.dart
+++ b/lib/ui/screen/onboarding_screen.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:places/presets/assets/icons.dart';
+import 'package:places/presets/strings/app_strings.dart';
+import 'package:places/presets/styles/app_sizes.dart';
+import 'package:places/ui/widgets/app_bar/app_bar_standard.dart';
+import 'package:places/ui/widgets/button/button_normal.dart';
+import 'package:places/ui/widgets/button/text_button_app_bar_action.dart';
+import 'package:places/ui/widgets/container/container_info_page.dart';
+
+/// Экран онбординга
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({Key? key}) : super(key: key);
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen>
+    with SingleTickerProviderStateMixin {
+  late final PageController _pageController = PageController();
+  late final TabController _tabController;
+  late final List<Map<String, String>> _pages;
+  int currentIndexPage = 0;
+
+  @override
+  void initState() {
+    _pages = _getPages();
+    _tabController = TabController(length: _pages.length, vsync: this);
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pageController.dispose();
+    _tabController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final titleStyle = theme.textTheme.headline4?.copyWith(
+      color: theme.primaryColorDark,
+    );
+    const indicatorSize = AppSizes.paddingCommon / 2;
+
+    return Scaffold(
+      appBar: AppBarStandard(
+        bottomWidget: const SizedBox(),
+        title: AppStrings.appEmptyString,
+        actions: currentIndexPage < _pages.length - 1
+            ? [
+                TextButtonAppBarAction(
+                  text: AppStrings.skip,
+                  action: () => _animateToPage(_pages.length - 1),
+                ),
+              ]
+            : [],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView(
+              controller: _pageController,
+              onPageChanged: (index) {
+                currentIndexPage = index;
+                _tabController.animateTo(index);
+                setState(() {});
+              },
+              children: _pages
+                  .map(
+                    (item) => ContainerInfoPage(
+                      icon: item['icon'].toString(),
+                      title: item['title'].toString(),
+                      description: item['description'].toString(),
+                      iconSize: 104,
+                      iconColor: theme.primaryColorDark,
+                      titleStyle: titleStyle,
+                      descriptionStyle: theme.textTheme.subtitle2,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(AppSizes.paddingDetailContentDivider),
+            width: MediaQuery.of(context).size.width,
+            alignment: Alignment.center,
+            child: TabBar(
+              controller: _tabController,
+              indicatorWeight: 0,
+              labelPadding: const EdgeInsets.symmetric(
+                horizontal: indicatorSize / 2,
+              ),
+              isScrollable: true,
+              indicator: BoxDecoration(
+                color: theme.colorScheme.tertiary,
+                borderRadius:
+                    const BorderRadius.all(AppSizes.radiusBtnImageSlider),
+              ),
+              indicatorSize: TabBarIndicatorSize.label,
+              onTap: (index) => setState(() {
+                _animateToPage(index);
+              }),
+              tabs: [
+                for (int i = 0; i < _pages.length; i++) ...[
+                  Container(
+                    height: indicatorSize,
+                    width: _tabController.index == i
+                        ? indicatorSize * 3
+                        : indicatorSize,
+                    decoration: BoxDecoration(
+                      color: _tabController.index == i
+                          ? Colors.transparent
+                          : theme.colorScheme.background,
+                      borderRadius: const BorderRadius.all(
+                        AppSizes.radiusBtnImageSlider,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          IgnorePointer(
+            ignoring: currentIndexPage < _pages.length - 1,
+            child: Opacity(
+              opacity: currentIndexPage < _pages.length - 1 ? 0 : 1,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSizes.paddingCommon,
+                  vertical: indicatorSize,
+                ),
+                child: ButtonNormal(
+                  text: AppStrings.toTheStart.toUpperCase(),
+                  action: () {},
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _animateToPage(int page) {
+    setState(() {
+      _pageController.animateToPage(
+        page,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOut,
+      );
+    });
+  }
+}
+
+List<Map<String, String>> _getPages() {
+  return <Map<String, String>>[
+    {
+      'icon': AppIcons.onBoardPageWelcome,
+      'title': AppStrings.onBoardPageWelcome,
+      'description': AppStrings.onBoardPageWelcomeDescription,
+    },
+    {
+      'icon': AppIcons.onBoardPageCreateRoute,
+      'title': AppStrings.onBoardPageCreateRoute,
+      'description': AppStrings.onBoardPageCreateRouteDescription,
+    },
+    {
+      'icon': AppIcons.onBoardPageAddSights,
+      'title': AppStrings.onBoardPageAddSights,
+      'description': AppStrings.onBoardPageAddSightsDescription,
+    },
+  ];
+}

--- a/lib/ui/screen/onboarding_screen.dart
+++ b/lib/ui/screen/onboarding_screen.dart
@@ -44,12 +44,13 @@ class _OnboardingScreenState extends State<OnboardingScreen>
       color: theme.primaryColorDark,
     );
     const indicatorSize = AppSizes.paddingCommon / 2;
+    final isNotLastPage = currentIndexPage < _pages.length - 1;
 
     return Scaffold(
       appBar: AppBarStandard(
         bottomWidget: const SizedBox(),
         title: AppStrings.appEmptyString,
-        actions: currentIndexPage < _pages.length - 1
+        actions: isNotLastPage
             ? [
                 TextButtonAppBarAction(
                   text: AppStrings.skip,
@@ -124,9 +125,9 @@ class _OnboardingScreenState extends State<OnboardingScreen>
             ),
           ),
           IgnorePointer(
-            ignoring: currentIndexPage < _pages.length - 1,
+            ignoring: isNotLastPage,
             child: Opacity(
-              opacity: currentIndexPage < _pages.length - 1 ? 0 : 1,
+              opacity: isNotLastPage ? 0 : 1,
               child: Padding(
                 padding: const EdgeInsets.symmetric(
                   horizontal: AppSizes.paddingCommon,

--- a/lib/ui/screen/res/themes.dart
+++ b/lib/ui/screen/res/themes.dart
@@ -32,6 +32,7 @@ class AppThemes {
       dividerColor: AppColors.inactiveBlack,
       disabledColor: AppColors.inactiveBlack,
       cardColor: AppColors.background,
+      indicatorColor: AppColors.whiteMain,
       iconTheme: const IconThemeData(
         color: AppColors.white,
         size: 24,
@@ -182,6 +183,7 @@ class AppThemes {
       dividerColor: AppColors.secondary2,
       disabledColor: AppColors.inactiveBlack,
       cardColor: AppColors.blackDark,
+      indicatorColor: AppColors.white,
       iconTheme: const IconThemeData(
         color: AppColors.white,
         size: 24,

--- a/lib/ui/screen/sight_search_screen.dart
+++ b/lib/ui/screen/sight_search_screen.dart
@@ -8,7 +8,7 @@ import 'package:places/ui/screen/sight_details.dart';
 import 'package:places/ui/screen/widgets/search_bar.dart';
 import 'package:places/ui/widgets/app_bar/app_bar_standard.dart';
 import 'package:places/ui/widgets/button/button_icon_svg.dart';
-import 'package:places/ui/widgets/container/container_empty_page.dart';
+import 'package:places/ui/widgets/container/container_info_page.dart';
 import 'package:places/ui/widgets/divider/divider_default.dart';
 import 'package:places/ui/widgets/lists/list_tile_standard.dart';
 import 'package:places/ui/widgets/lists/list_tile_with_image.dart';
@@ -81,7 +81,7 @@ class _ScreenState extends State<_Screen> {
               case SightSearchStatus.done:
                 return const _FoundedSights();
               default:
-                return const ContainerEmptyPage(
+                return const ContainerInfoPage(
                   icon: AppIcons.emptyPageSearch,
                   title: AppStrings.foundNothing,
                   description: AppStrings.emptyPageFoundNothing,

--- a/lib/ui/screen/visiting_screen.dart
+++ b/lib/ui/screen/visiting_screen.dart
@@ -8,7 +8,7 @@ import 'package:places/presets/strings/app_strings.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/screen/visiting_card.dart';
 import 'package:places/ui/widgets/app_bar/app_bar_standard.dart';
-import 'package:places/ui/widgets/container/container_empty_page.dart';
+import 'package:places/ui/widgets/container/container_info_page.dart';
 import 'package:places/ui/widgets/navigation_bar/bottom_navigation_view.dart';
 
 /// Экран "Хочу посетить/Посещенные места"
@@ -96,12 +96,12 @@ class _PageViewState extends State<_PageView> {
             },
           )
         : widget.forVisited
-            ? const ContainerEmptyPage(
+            ? const ContainerInfoPage(
                 icon: AppIcons.emptyPageGo,
                 title: AppStrings.empty,
                 description: AppStrings.emptyPageVisited,
               )
-            : const ContainerEmptyPage(
+            : const ContainerInfoPage(
                 icon: AppIcons.emptyPageCard,
                 title: AppStrings.empty,
                 description: AppStrings.emptyPageWantToVisit,

--- a/lib/ui/screen/widgets/image_slider.dart
+++ b/lib/ui/screen/widgets/image_slider.dart
@@ -55,69 +55,71 @@ class _ImageSliderState extends State<ImageSlider>
                   ))
               .toList(),
         ),
-        Positioned(
-          bottom: 0,
-          child: SizedBox(
-            height: 8,
-            width: MediaQuery.of(context).size.width,
-            child: TabBar(
-              controller: _tabController,
-              labelPadding: EdgeInsets.zero,
-              indicatorWeight: 0,
-              onTap: (index) {
-                _pageController.animateToPage(
-                  index,
-                  duration: const Duration(milliseconds: 400),
-                  curve: Curves.easeInOut,
-                );
-              },
-              indicator: BoxDecoration(
-                color: theme.indicatorColor,
-                borderRadius: _tabController.index < widget.imageUrls.length - 1
-                    ? const BorderRadius.only(
-                        topRight: AppSizes.radiusBtnSwitch,
-                        bottomRight: AppSizes.radiusBtnSwitch,
-                      )
-                    : null,
-              ),
-              tabs: widget.imageUrls.map((imageUrl) {
-                final tabIndex = widget.imageUrls.indexOf(imageUrl);
+        if (widget.imageUrls.length > 1)
+          Positioned(
+            bottom: 0,
+            child: SizedBox(
+              height: 8,
+              width: MediaQuery.of(context).size.width,
+              child: TabBar(
+                controller: _tabController,
+                labelPadding: EdgeInsets.zero,
+                indicatorWeight: 0,
+                onTap: (index) {
+                  _pageController.animateToPage(
+                    index,
+                    duration: const Duration(milliseconds: 400),
+                    curve: Curves.easeInOut,
+                  );
+                },
+                indicator: BoxDecoration(
+                  color: theme.indicatorColor,
+                  borderRadius:
+                      _tabController.index < widget.imageUrls.length - 1
+                          ? const BorderRadius.only(
+                              topRight: AppSizes.radiusBtnSwitch,
+                              bottomRight: AppSizes.radiusBtnSwitch,
+                            )
+                          : null,
+                ),
+                tabs: widget.imageUrls.map((imageUrl) {
+                  final tabIndex = widget.imageUrls.indexOf(imageUrl);
 
-                return Stack(
-                  children: [
-                    if (tabIndex <= _tabController.index)
-                      Container(
-                        height: double.infinity,
-                        width: double.infinity,
-                        decoration: BoxDecoration(
-                          color: theme.indicatorColor,
-                          borderRadius: const BorderRadius.only(
-                            topRight: AppSizes.radiusBtnSwitch,
-                            bottomRight: AppSizes.radiusBtnSwitch,
+                  return Stack(
+                    children: [
+                      if (tabIndex <= _tabController.index)
+                        Container(
+                          height: double.infinity,
+                          width: double.infinity,
+                          decoration: BoxDecoration(
+                            color: theme.indicatorColor,
+                            borderRadius: const BorderRadius.only(
+                              topRight: AppSizes.radiusBtnSwitch,
+                              bottomRight: AppSizes.radiusBtnSwitch,
+                            ),
                           ),
                         ),
-                      ),
-                    Tab(
-                      child: Container(
-                        color: tabIndex < _tabController.index
-                            ? theme.indicatorColor
-                            : Colors.transparent,
-                      ),
-                    ),
-                    if (tabIndex > 0 && tabIndex <= _tabController.index)
-                      ColoredBox(
-                        color: theme.colorScheme.secondary,
-                        child: const SizedBox(
-                          height: double.maxFinite,
-                          width: 1,
+                      Tab(
+                        child: Container(
+                          color: tabIndex < _tabController.index
+                              ? theme.indicatorColor
+                              : Colors.transparent,
                         ),
                       ),
-                  ],
-                );
-              }).toList(),
+                      if (tabIndex > 0 && tabIndex <= _tabController.index)
+                        ColoredBox(
+                          color: theme.colorScheme.secondary,
+                          child: const SizedBox(
+                            height: double.maxFinite,
+                            width: 1,
+                          ),
+                        ),
+                    ],
+                  );
+                }).toList(),
+              ),
             ),
           ),
-        ),
       ],
     );
   }

--- a/lib/ui/screen/widgets/image_slider.dart
+++ b/lib/ui/screen/widgets/image_slider.dart
@@ -1,0 +1,124 @@
+// Слайдер картинок
+import 'package:flutter/material.dart';
+import 'package:places/presets/styles/app_sizes.dart';
+import 'package:places/ui/widgets/container/container_for_image_network.dart';
+
+class ImageSlider extends StatefulWidget {
+  final List<String> imageUrls;
+
+  const ImageSlider({
+    Key? key,
+    required this.imageUrls,
+  }) : super(key: key);
+
+  @override
+  State<ImageSlider> createState() => _ImageSliderState();
+}
+
+class _ImageSliderState extends State<ImageSlider>
+    with SingleTickerProviderStateMixin {
+  late final PageController _pageController;
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    _pageController = PageController();
+    _tabController =
+        TabController(length: widget.imageUrls.length, vsync: this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Stack(
+      children: [
+        PageView(
+          controller: _pageController,
+          onPageChanged: (index) {
+            setState(() {
+              _tabController.animateTo(index);
+            });
+          },
+          children: widget.imageUrls
+              .map((imageUrl) => ContainerForImageNetwork(
+                    url: imageUrl,
+                    height: double.infinity,
+                  ))
+              .toList(),
+        ),
+        Positioned(
+          bottom: 0,
+          child: SizedBox(
+            height: 8,
+            width: MediaQuery.of(context).size.width,
+            child: TabBar(
+              controller: _tabController,
+              labelPadding: EdgeInsets.zero,
+              indicatorWeight: 0,
+              onTap: (index) {
+                _pageController.animateToPage(
+                  index,
+                  duration: const Duration(milliseconds: 400),
+                  curve: Curves.easeInOut,
+                );
+              },
+              indicator: BoxDecoration(
+                color: theme.indicatorColor,
+                borderRadius: _tabController.index < widget.imageUrls.length - 1
+                    ? const BorderRadius.only(
+                        topRight: AppSizes.radiusBtnSwitch,
+                        bottomRight: AppSizes.radiusBtnSwitch,
+                      )
+                    : null,
+              ),
+              tabs: widget.imageUrls.map((imageUrl) {
+                final tabIndex = widget.imageUrls.indexOf(imageUrl);
+
+                return Stack(
+                  children: [
+                    if (tabIndex <= _tabController.index)
+                      Container(
+                        height: double.infinity,
+                        width: double.infinity,
+                        decoration: BoxDecoration(
+                          color: theme.indicatorColor,
+                          borderRadius: const BorderRadius.only(
+                            topRight: AppSizes.radiusBtnSwitch,
+                            bottomRight: AppSizes.radiusBtnSwitch,
+                          ),
+                        ),
+                      ),
+                    Tab(
+                      child: Container(
+                        color: tabIndex < _tabController.index
+                            ? theme.indicatorColor
+                            : Colors.transparent,
+                      ),
+                    ),
+                    if (tabIndex > 0 && tabIndex <= _tabController.index)
+                      ColoredBox(
+                        color: theme.colorScheme.secondary,
+                        child: const SizedBox(
+                          height: double.maxFinite,
+                          width: 1,
+                        ),
+                      ),
+                  ],
+                );
+              }).toList(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/widgets/app_bar/app_bar_sight_details.dart
+++ b/lib/ui/widgets/app_bar/app_bar_sight_details.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/ui/screen/widgets/image_slider.dart';
 import 'package:places/ui/widgets/button/button_top_navigation.dart';
-import 'package:places/ui/widgets/container/container_for_image_network.dart';
 
 /// AppBar для экранов списка
 class AppBarSightDetails extends StatelessWidget

--- a/lib/ui/widgets/app_bar/app_bar_sight_details.dart
+++ b/lib/ui/widgets/app_bar/app_bar_sight_details.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:places/presets/styles/app_sizes.dart';
+import 'package:places/ui/screen/widgets/image_slider.dart';
 import 'package:places/ui/widgets/button/button_top_navigation.dart';
 import 'package:places/ui/widgets/container/container_for_image_network.dart';
 
@@ -17,8 +19,6 @@ class AppBarSightDetails extends StatelessWidget
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
     return AppBar(
       toolbarHeight: AppSizes.heightAppBarImage,
       automaticallyImplyLeading: false,
@@ -26,31 +26,17 @@ class AppBarSightDetails extends StatelessWidget
       title: SizedBox(
         height: AppSizes.heightAppBarImage,
         child: Stack(
-          children: [
-            const Positioned(
+          children: const [
+            Positioned(
               top: 12,
               left: 16,
               child: ButtonTopNavigation(),
             ),
-            Positioned(
-              bottom: 0,
-              left: -8,
-              child: Container(
-                width: 152,
-                height: 8,
-                decoration: BoxDecoration(
-                  color: theme.primaryColorDark,
-                  borderRadius:
-                      const BorderRadius.all(AppSizes.radiusBtnImageSlider),
-                ),
-              ),
-            ),
           ],
         ),
       ),
-      flexibleSpace: ContainerForImageNetwork(
-        url: imageUrls.first,
-        height: double.infinity,
+      flexibleSpace: ImageSlider(
+        imageUrls: imageUrls,
       ),
       systemOverlayStyle: SystemUiOverlayStyle.light.copyWith(
         statusBarColor: Colors.transparent,

--- a/lib/ui/widgets/container/container_info_page.dart
+++ b/lib/ui/widgets/container/container_info_page.dart
@@ -5,15 +5,23 @@ import 'package:places/presets/styles/app_sizes.dart';
 import 'package:places/presets/styles/text_styles.dart';
 
 /// Контайнер для пустых страниц
-class ContainerEmptyPage extends StatelessWidget {
+class ContainerInfoPage extends StatelessWidget {
   final String icon;
   final String title;
   final String description;
+  final Color iconColor;
+  final double? iconSize;
+  final TextStyle? titleStyle;
+  final TextStyle? descriptionStyle;
 
-  const ContainerEmptyPage({
+  const ContainerInfoPage({
     required this.icon,
     required this.title,
     required this.description,
+    this.iconColor = AppColors.inactiveBlack,
+    this.iconSize,
+    this.titleStyle,
+    this.descriptionStyle,
     Key? key,
   }) : super(key: key);
 
@@ -25,27 +33,30 @@ class ContainerEmptyPage extends StatelessWidget {
         children: [
           SvgPicture.asset(
             icon,
-            color: AppColors.inactiveBlack,
-            height: AppSizes.sizeIconEmptyPage.height,
-            width: AppSizes.sizeIconEmptyPage.width,
+            color: iconColor,
+            height: iconSize ?? AppSizes.sizeIconEmptyPage.height,
+            width: iconSize ?? AppSizes.sizeIconEmptyPage.width,
           ),
           const SizedBox(
             height: AppSizes.paddingCommon * 2,
           ),
           Text(
             title,
-            style: AppTextStyles.subtitle.copyWith(
-              color: AppColors.inactiveBlack,
-            ),
+            style: titleStyle ??
+                AppTextStyles.subtitle.copyWith(
+                  color: AppColors.inactiveBlack,
+                ),
+            textAlign: TextAlign.center,
           ),
           const SizedBox(
             height: AppSizes.paddingCommon / 2,
           ),
           Text(
             description,
-            style: AppTextStyles.small.copyWith(
-              color: AppColors.inactiveBlack,
-            ),
+            style: descriptionStyle ??
+                AppTextStyles.small.copyWith(
+                  color: AppColors.inactiveBlack,
+                ),
             textAlign: TextAlign.center,
           ),
         ],


### PR DESCRIPTION
### Галерея на экране детализации интересного места
На экране детализации интересного места, галерею выполнить на pageView согласно дизайну
  - Сделать возможность перелистывать в ручную
  - У галереи должен быть индикатор по дизайну
  - Количество разделов индикатора соответствует количеству фотографий

Видео работающей галереи:
https://drive.google.com/file/d/1qQ08rfzXKAOXJJPUQzbXFRpoXoPVDNzT/view?usp=sharing

### Онбординг
На экране онбординга отображает подсказку - как пользоваться приложением. 
Экран отображается при первом запуске приложения или через экран настроек.

  - Создайте в папке ui/screens экран OnboardingScreen
  - Сверстайте ui экрана по дизайну на PageView. 
  - Индикатор перелистывания на текущем этапе можно оставить без анимации
  - Проверку на первый вход реализуете во время прохождения раздела "Тема 15. Хранение данных".
 
Видео:
https://drive.google.com/file/d/1SuDBPrVYdefhB9j-BPrSzXg_lys_oqFv/view?usp=sharing
